### PR TITLE
Tests fuer den Zugriff auf Felder über Feld-Enums

### DIFF
--- a/lib/src/test/java/gdv/xport/AllTests.java
+++ b/lib/src/test/java/gdv/xport/AllTests.java
@@ -26,6 +26,7 @@ import gdv.xport.demo.DemoTests;
 import gdv.xport.feld.FeldTests;
 import gdv.xport.io.IoTests;
 import gdv.xport.satz.SatzTests;
+import gdv.xport.satz.feld.SpartenTests;
 import gdv.xport.util.UtilTests;
 import patterntesting.runtime.junit.SmokeSuite;
 
@@ -39,7 +40,7 @@ import patterntesting.runtime.junit.SmokeSuite;
  * @since 0.7 (11.01.2012)
  */
 @RunWith(SmokeSuite.class)
-@SuiteClasses({ ConfigTests.class, DemoTests.class, FeldTests.class, IoTests.class, SatzTests.class, UtilTests.class,
+@SuiteClasses({ ConfigTests.class, DemoTests.class, FeldTests.class, SpartenTests.class, IoTests.class, SatzTests.class, UtilTests.class,
         BasisTest.class, DatenpaketStreamerTest.class, DatenpaketTest.class, MainTest.class })
 public class AllTests {
 

--- a/lib/src/test/java/gdv/xport/satz/feld/SpartenTests.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/SpartenTests.java
@@ -1,0 +1,41 @@
+package gdv.xport.satz.feld;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import gdv.xport.satz.feld.sparte10.Sparte10Test;
+import gdv.xport.satz.feld.sparte10.wagnisart13.Sparte10Wagnis13Test;
+import gdv.xport.satz.feld.sparte10.wagnisart2.Sparte10Wagnis2Test;
+import gdv.xport.satz.feld.sparte10.wagnisart48.Sparte10Wagnis48Test;
+import gdv.xport.satz.feld.sparte10.wagnisart5.Sparte10Wagnis5Test;
+import gdv.xport.satz.feld.sparte10.wagnisart6.Sparte10Wagnis6Test;
+import gdv.xport.satz.feld.sparte10.wagnisart7.Sparte10Wagnis7Test;
+import gdv.xport.satz.feld.sparte10.wagnisart9.Sparte10Wagnis9Test;
+import gdv.xport.satz.feld.sparte110.Sparte110Test;
+import gdv.xport.satz.feld.sparte130.Sparte130Test;
+import gdv.xport.satz.feld.sparte140.Sparte140Test;
+import gdv.xport.satz.feld.sparte30.Sparte30Test;
+import gdv.xport.satz.feld.sparte40.Sparte40Test;
+import gdv.xport.satz.feld.sparte50.Sparte50Test;
+import gdv.xport.satz.feld.sparte51.Sparte51Test;
+import gdv.xport.satz.feld.sparte52.Sparte52Test;
+import gdv.xport.satz.feld.sparte53.Sparte53Test;
+import gdv.xport.satz.feld.sparte70.Sparte70Test;
+
+/**
+ * Die Klasse SpartenTests ist eine Test-Suite fuer JUnit, mit der alle
+ * JUnit-Tests fuer den Zugriff auf Felder via Enums getestet werden.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(Suite.class)
+@SuiteClasses({ Sparte10Wagnis13Test.class, Sparte10Wagnis2Test.class, Sparte10Wagnis48Test.class,
+        Sparte10Wagnis5Test.class, Sparte10Wagnis6Test.class, Sparte10Wagnis7Test.class, Sparte10Wagnis9Test.class,
+        Sparte10Test.class, Sparte110Test.class, Sparte130Test.class, Sparte140Test.class, Sparte30Test.class,
+        Sparte40Test.class, Sparte50Test.class, Sparte51Test.class, Sparte52Test.class, Sparte53Test.class,
+        Sparte70Test.class })
+public class SpartenTests {
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/Sparte10Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/Sparte10Test.java
@@ -1,0 +1,34 @@
+package gdv.xport.satz.feld.sparte10;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld210() {
+        checkEntries(new SatzX(210, Feld210.values()), Feld210.values());
+    }
+
+    @Test
+    public void testFeld211() {
+        checkEntries(new SatzX(211, Feld211.values()), Feld211.values());
+    }
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220Wagnis0.values()), Feld220Wagnis0.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart13/Sparte10Wagnis13Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart13/Sparte10Wagnis13Test.java
@@ -1,0 +1,61 @@
+package gdv.xport.satz.feld.sparte10.wagnisart13;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10, Wagnisart 1 und 3.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Wagnis13Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220Wagnis13() {
+        checkEntries(new SatzX(220, Feld220Wagnis13.values()), Feld220Wagnis13.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis13Auszahlungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis13Auszahlungen.values()), Feld220Wagnis13Auszahlungen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis13Bezugsrechte() {
+        checkEntries(new SatzX(220, Feld220Wagnis13Bezugsrechte.values()), Feld220Wagnis13Bezugsrechte.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis13Wertungssummen() {
+        checkEntries(new SatzX(220, Feld220Wagnis13Wertungssummen.values()), Feld220Wagnis13Wertungssummen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis13ZukSummenaenderungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis13ZukSummenaenderungen.values()),
+                Feld220Wagnis13ZukSummenaenderungen.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis13() {
+        checkEntries(new SatzX(221, Feld221Wagnis13.values()), Feld221Wagnis13.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis13Auszahlungen() {
+        checkEntries(new SatzX(221, Feld221Wagnis13Auszahlungen.values()), Feld221Wagnis13Auszahlungen.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis13ZukSummenaenderungen() {
+        checkEntries(new SatzX(221, Feld221Wagnis13ZukSummenaenderungen.values()),
+                Feld221Wagnis13ZukSummenaenderungen.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart2/Sparte10Wagnis2Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart2/Sparte10Wagnis2Test.java
@@ -1,0 +1,61 @@
+package gdv.xport.satz.feld.sparte10.wagnisart2;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10, Wagnisart 2.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Wagnis2Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220Wagnis2() {
+        checkEntries(new SatzX(220, Feld220Wagnis2.values()), Feld220Wagnis2.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis2Auszahlungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis2Auszahlungen.values()), Feld220Wagnis2Auszahlungen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis2Bezugsrechte() {
+        checkEntries(new SatzX(220, Feld220Wagnis2Bezugsrechte.values()), Feld220Wagnis2Bezugsrechte.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis2Wertungssummen() {
+        checkEntries(new SatzX(220, Feld220Wagnis2Wertungssummen.values()), Feld220Wagnis2Wertungssummen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis2ZukSummenaenderungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis2ZukSummenaenderungen.values()),
+                Feld220Wagnis2ZukSummenaenderungen.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis2() {
+        checkEntries(new SatzX(221, Feld221Wagnis2.values()), Feld221Wagnis2.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis2Auszahlungen() {
+        checkEntries(new SatzX(221, Feld221Wagnis2Auszahlungen.values()), Feld221Wagnis2Auszahlungen.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis2ZukSummenaenderungen() {
+        checkEntries(new SatzX(221, Feld221Wagnis2ZukSummenaenderungen.values()),
+                Feld221Wagnis2ZukSummenaenderungen.values());
+    }
+    
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart48/Sparte10Wagnis48Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart48/Sparte10Wagnis48Test.java
@@ -1,0 +1,45 @@
+package gdv.xport.satz.feld.sparte10.wagnisart48;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10, Wagnisart 4 und 8.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Wagnis48Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220Wagnis48() {
+        checkEntries(new SatzX(220, Feld220Wagnis48.values()), Feld220Wagnis48.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis48Bezugsrechte() {
+        checkEntries(new SatzX(220, Feld220Wagnis48Bezugsrechte.values()), Feld220Wagnis48Bezugsrechte.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis48Wertungssummen() {
+        checkEntries(new SatzX(220, Feld220Wagnis48Wertungssummen.values()), Feld220Wagnis48Wertungssummen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis48ZukSummenaenderungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis48ZukSummenaenderungen.values()),
+                Feld220Wagnis48ZukSummenaenderungen.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis48() {
+        checkEntries(new SatzX(221, Feld221Wagnis48.values()), Feld221Wagnis48.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart5/Sparte10Wagnis5Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart5/Sparte10Wagnis5Test.java
@@ -1,0 +1,51 @@
+package gdv.xport.satz.feld.sparte10.wagnisart5;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10, Wagnisart 5.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Wagnis5Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220Wagnis5() {
+        checkEntries(new SatzX(220, Feld220Wagnis5.values()), Feld220Wagnis5.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis5Bezugsrechte() {
+        checkEntries(new SatzX(220, Feld220Wagnis5Bezugsrechte.values()), Feld220Wagnis5Bezugsrechte.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis5Wertungssummen() {
+        checkEntries(new SatzX(220, Feld220Wagnis5Wertungssummen.values()), Feld220Wagnis5Wertungssummen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis5ZukSummenaenderungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis5ZukSummenaenderungen.values()),
+                Feld220Wagnis5ZukSummenaenderungen.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis5() {
+        checkEntries(new SatzX(221, Feld221Wagnis5.values()), Feld221Wagnis5.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis5ZukSummenaenderungen() {
+        checkEntries(new SatzX(221, Feld221Wagnis5ZukSummenaenderungen.values()),
+                Feld221Wagnis5ZukSummenaenderungen.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart6/Sparte10Wagnis6Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart6/Sparte10Wagnis6Test.java
@@ -1,0 +1,51 @@
+package gdv.xport.satz.feld.sparte10.wagnisart6;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10, Wagnisart 6.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Wagnis6Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220Wagnis6() {
+        checkEntries(new SatzX(220, Feld220Wagnis6.values()), Feld220Wagnis6.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis6Bezugsrechte() {
+        checkEntries(new SatzX(220, Feld220Wagnis6Bezugsrechte.values()), Feld220Wagnis6Bezugsrechte.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis6Wertungssummen() {
+        checkEntries(new SatzX(220, Feld220Wagnis6Wertungssummen.values()), Feld220Wagnis6Wertungssummen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis6ZukSummenaenderungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis6ZukSummenaenderungen.values()),
+                Feld220Wagnis6ZukSummenaenderungen.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis6() {
+        checkEntries(new SatzX(221, Feld221Wagnis6.values()), Feld221Wagnis6.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis6ZukSummenaenderungen() {
+        checkEntries(new SatzX(221, Feld221Wagnis6ZukSummenaenderungen.values()),
+                Feld221Wagnis6ZukSummenaenderungen.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart7/Sparte10Wagnis7Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart7/Sparte10Wagnis7Test.java
@@ -1,0 +1,50 @@
+package gdv.xport.satz.feld.sparte10.wagnisart7;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10, Wagnisart 7.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Wagnis7Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220Wagnis7() {
+        checkEntries(new SatzX(220, Feld220Wagnis7.values()), Feld220Wagnis7.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis7Bezugsrechte() {
+        checkEntries(new SatzX(220, Feld220Wagnis7Bezugsrechte.values()), Feld220Wagnis7Bezugsrechte.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis7Wertungssummen() {
+        checkEntries(new SatzX(220, Feld220Wagnis7Wertungssummen.values()), Feld220Wagnis7Wertungssummen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis7ZukSummenaenderungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis7ZukSummenaenderungen.values()),
+                Feld220Wagnis7ZukSummenaenderungen.values());
+    }
+    @Test
+    public void testFeld221Wagnis7() {
+        checkEntries(new SatzX(221, Feld221Wagnis7.values()), Feld221Wagnis7.values());
+    }
+
+    @Test
+    public void testFeld221Wagnis7ZukSummenaenderungen() {
+        checkEntries(new SatzX(221, Feld221Wagnis7ZukSummenaenderungen.values()),
+                Feld221Wagnis7ZukSummenaenderungen.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart9/Sparte10Wagnis9Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte10/wagnisart9/Sparte10Wagnis9Test.java
@@ -1,0 +1,50 @@
+package gdv.xport.satz.feld.sparte10.wagnisart9;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 10, Wagnisart 9.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte10Wagnis9Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220Wagnis9() {
+        checkEntries(new SatzX(220, Feld220Wagnis9.values()), Feld220Wagnis9.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis9Auszahlungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis9Auszahlungen.values()), Feld220Wagnis9Auszahlungen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis9Bezugsrechte() {
+        checkEntries(new SatzX(220, Feld220Wagnis9Bezugsrechte.values()), Feld220Wagnis9Bezugsrechte.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis9Wertungssummen() {
+        checkEntries(new SatzX(220, Feld220Wagnis9Wertungssummen.values()), Feld220Wagnis9Wertungssummen.values());
+    }
+
+    @Test
+    public void testFeld220Wagnis9ZukSummenaenderungen() {
+        checkEntries(new SatzX(220, Feld220Wagnis9ZukSummenaenderungen.values()),
+                Feld220Wagnis9ZukSummenaenderungen.values());
+    }
+
+    @Test
+    public void testFeld230() {
+        checkEntries(new SatzX(230, Feld230.values()), Feld230.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte110/Sparte110Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte110/Sparte110Test.java
@@ -1,0 +1,24 @@
+package gdv.xport.satz.feld.sparte110;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 110.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte110Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte130/Sparte130Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte130/Sparte130Test.java
@@ -1,0 +1,24 @@
+package gdv.xport.satz.feld.sparte130;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 130.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte130Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld210() {
+        checkEntries(new SatzX(210, Feld210.values()), Feld210.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte140/Sparte140Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte140/Sparte140Test.java
@@ -1,0 +1,18 @@
+package gdv.xport.satz.feld.sparte140;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+@RunWith(SmokeRunner.class)
+public class Sparte140Test  extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte30/Sparte30Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte30/Sparte30Test.java
@@ -1,0 +1,44 @@
+package gdv.xport.satz.feld.sparte30;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 30.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte30Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld210() {
+        checkEntries(new SatzX(210, Feld210.values()), Feld210.values());
+    }
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+
+    @Test
+    public void testFeld221() {
+        checkEntries(new SatzX(221, Feld221.values()), Feld221.values());
+    }
+
+    @Test
+    public void testFeld222() {
+        checkEntries(new SatzX(222, Feld222.values()), Feld222.values());
+    }
+
+    @Test
+    public void testFeld230() {
+        checkEntries(new SatzX(230, Feld230.values()), Feld230.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte40/Sparte40Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte40/Sparte40Test.java
@@ -1,0 +1,39 @@
+package gdv.xport.satz.feld.sparte40;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 40.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte40Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld210() {
+        checkEntries(new SatzX(210, Feld210.values()), Feld210.values());
+    }
+
+    @Test
+    public void testFeld211() {
+        checkEntries(new SatzX(211, Feld211.values()), Feld211.values());
+    }
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+
+    @Test
+    public void testFeld221() {
+        checkEntries(new SatzX(221, Feld221.values()), Feld221.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte50/Sparte50Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte50/Sparte50Test.java
@@ -1,0 +1,29 @@
+package gdv.xport.satz.feld.sparte50;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 50.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte50Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld210() {
+        checkEntries(new SatzX(210, Feld210.values()), Feld210.values());
+    }
+
+    @Test
+    public void testFeld211() {
+        checkEntries(new SatzX(211, Feld211.values()), Feld211.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte51/Sparte51Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte51/Sparte51Test.java
@@ -1,0 +1,29 @@
+package gdv.xport.satz.feld.sparte51;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 51.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte51Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+
+    @Test
+    public void testFeld221() {
+        checkEntries(new SatzX(221, Feld221.values()), Feld221.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte52/Sparte52Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte52/Sparte52Test.java
@@ -1,0 +1,29 @@
+package gdv.xport.satz.feld.sparte52;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 52.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte52Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+
+    @Test
+    public void testFeld221() {
+        checkEntries(new SatzX(221, Feld221.values()), Feld221.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte53/Sparte53Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte53/Sparte53Test.java
@@ -1,0 +1,28 @@
+package gdv.xport.satz.feld.sparte53;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 53.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte53Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+    
+    @Test
+    public void testFeld221() {
+        checkEntries(new SatzX(221, Feld221.values()), Feld221.values());
+    }
+
+}

--- a/lib/src/test/java/gdv/xport/satz/feld/sparte70/Sparte70Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte70/Sparte70Test.java
@@ -1,0 +1,34 @@
+package gdv.xport.satz.feld.sparte70;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import gdv.xport.satz.feld.AbstractFeldTest;
+import gdv.xport.satz.model.SatzX;
+import patterntesting.runtime.junit.SmokeRunner;
+
+/**
+ * Diese Klasse testet den Zugriff auf Felder via Enums fuer die Sparte 70.
+ * 
+ * @author Ken Schosinsky
+ * @since 3.1.0 (08.04.2018)
+ */
+@RunWith(SmokeRunner.class)
+public class Sparte70Test extends AbstractFeldTest {
+
+    @Test
+    public void testFeld210() {
+        checkEntries(new SatzX(210, Feld210.values()), Feld210.values());
+    }
+
+    @Test
+    public void testFeld220() {
+        checkEntries(new SatzX(220, Feld220.values()), Feld220.values());
+    }
+
+    @Test
+    public void testFeld221() {
+        checkEntries(new SatzX(221, Feld221.values()), Feld221.values());
+    }
+
+}


### PR DESCRIPTION
Nach weiterer Implementierung eines GDV-Importers mit dieser Library sind mir bei der Verwendung der Enums noch weitere Fehler aufgefallen.

Darum habe ich für alle Enums nach Sparten (und Wagnisart) sortiert Tests geschrieben. 31 der 71 Enums, für die ich Tests schrieb, enthalten Fehler.

Ich helfe gerne auch bei der Behebung der Fehler, würde aber wissen wollen, wie ich das am besten angehen sollte.

Grüße,
schosins