### PR TITLE
Fixed #27, FeldInfos in Enums korrigiert

### DIFF
--- a/lib/src/main/java/gdv/xport/feld/NumFeld.java
+++ b/lib/src/main/java/gdv/xport/feld/NumFeld.java
@@ -286,10 +286,11 @@ public class NumFeld extends Feld {
      */
     public double toDouble() {
         double n = toLong();
+        long d = 1;
         for (int i = 0; i < this.nachkommastellen; i++) {
-            n /= 10;
+            d *= 10;
         }
-        return n;
+        return n / d;
     }
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/common/VertragsStatus.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/common/VertragsStatus.java
@@ -62,7 +62,7 @@ public enum VertragsStatus {
     @FeldInfo(
             teildatensatz = 1,
             nr = 10,
-            type = NumFeld.class,
+            type = Datum.class,
             anzahlBytes = 8,
             byteAdresse = 52
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/Feld210.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/Feld210.java
@@ -105,7 +105,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 12,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 12,
             byteAdresse = 49
     )
@@ -219,6 +219,7 @@ public enum Feld210 {
             nr = 20,
             type = NumFeld.class,
             anzahlBytes = 5,
+            nachkommaStellen = 2,
             byteAdresse = 131
     )
     BESTANDSPFLEGEPROVISION,
@@ -280,7 +281,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 24,
-            type = NumFeld.class,
+            type = Datum.class,
             anzahlBytes = 8,
             byteAdresse = 151
     )
@@ -751,7 +752,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 25,
-            type = NumFeld.class,
+            type = Datum.class,
             anzahlBytes = 8,
             byteAdresse = 224
             )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/Feld211.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/Feld211.java
@@ -47,7 +47,7 @@ public enum Feld211 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 8,
-            type = NumFeld.class,
+            type = Betrag.class,
             nachkommaStellen = 2,
             anzahlBytes = 14,
             byteAdresse = 43
@@ -60,7 +60,7 @@ public enum Feld211 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 9,
-            type = NumFeld.class,
+            type = Betrag.class,
             nachkommaStellen = 2,
             anzahlBytes = 12,
             byteAdresse = 57

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/Feld220Wagnis0.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/Feld220Wagnis0.java
@@ -111,7 +111,7 @@ public enum Feld220Wagnis0 {
     /**
      * Anzahl der versicherten Personen.
      */
-    @FeldInfo(teildatensatz = 1, nr = 17, type = Zeichen.class, anzahlBytes = 1, byteAdresse = 164)
+    @FeldInfo(teildatensatz = 1, nr = 17, type = NumFeld.class, anzahlBytes = 1, byteAdresse = 164)
     ANZAHL_DER_VERSICHERTEN_PERSONEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13.java
@@ -126,7 +126,7 @@ public enum Feld220Wagnis13 {
      * zum Ablauf (inkl. Abrufphase)
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 18, type = Betrag.class, anzahlBytes = 9, byteAdresse = 111)
+    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 111)
     TODESFALL_VS_IN_WAEHRUNGSEINHEIT_ZUM_ABLAUF,
 
     /**
@@ -221,7 +221,7 @@ public enum Feld220Wagnis13 {
      * Dynamik %-Satz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 31, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 193)
+    @FeldInfo(teildatensatz = 1, nr = 31, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 193)
     DYNAMIK_PROZENT_SATZ,
 
     /**
@@ -291,7 +291,7 @@ public enum Feld220Wagnis13 {
      * kumuliert, incl. aller Dynamiken
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 39, type = Betrag.class, anzahlBytes = 9, byteAdresse = 222)
+    @FeldInfo(teildatensatz = 1, nr = 39, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 222)
     RUECKKAUFSWERT_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13Auszahlungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13Auszahlungen.java
@@ -88,7 +88,7 @@ public enum Feld220Wagnis13Auszahlungen {
      * wurde (NAECHSTE_AUSZAHLUNGSSUMMER_IN_WAEHRUNGSEINHEITEN).
      * </p>
      */
-    @FeldInfo(teildatensatz = 1, nr = 12, type = Betrag.class, anzahlBytes = 9, byteAdresse = 64)
+    @FeldInfo(teildatensatz = 1, nr = 12, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 64)
     NAECHSTE_AUSZAHLUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13Bezugsrechte.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13Bezugsrechte.java
@@ -96,7 +96,7 @@ public enum Feld220Wagnis13Bezugsrechte {
     /**
      * Bezugsrechtanteil im Erlebensfall in Prozent (3,2 Stellen).
      */
-    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 95)
     BEZUGSRECHTANTEIL_IM_ERLEBENSFALL,
 
     /**
@@ -127,7 +127,7 @@ public enum Feld220Wagnis13Bezugsrechte {
      * Bezugsrechtanteil im Todesfall.
      * in Prozent (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 132)
+    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 132)
     BEZUGSRECHTANTEIL_IM_TODESFALL,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld220Wagnis13ZukSummenaenderungen.java
@@ -111,7 +111,7 @@ public enum Feld220Wagnis13ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Todesfalleistung
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 77)
+    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 77)
     TODESFALLAENDERUNGS_PROZENTSATZ,
 
     /**
@@ -119,7 +119,7 @@ public enum Feld220Wagnis13ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfalleistung
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 16, type = Betrag.class, anzahlBytes = 9, byteAdresse = 82)
+    @FeldInfo(teildatensatz = 1, nr = 16, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 82)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_VS_IN_WAEHRUNGSEINHEITEN,
 
     /**
@@ -170,7 +170,7 @@ public enum Feld220Wagnis13ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Erlebensfall VS
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 121)
+    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 121)
     ERLEBENSFALL_VS_AENDERUNGS_PROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld221Wagnis13Auszahlungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld221Wagnis13Auszahlungen.java
@@ -77,7 +77,7 @@ public enum Feld221Wagnis13Auszahlungen {
      * wurde (NAECHSTE_AUSZAHLUNGSSUMMER_IN_WAEHRUNGSEINHEITEN).
      * </p>
      */
-    @FeldInfo(teildatensatz = 1, nr = 12, type = Betrag.class, anzahlBytes = 9, byteAdresse = 64)
+    @FeldInfo(teildatensatz = 1, nr = 12, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 64)
     NAECHSTE_AUSZAHLUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld221Wagnis13ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart13/Feld221Wagnis13ZukSummenaenderungen.java
@@ -81,7 +81,7 @@ public enum Feld221Wagnis13ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfalleistung
      * (12,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 13, type = Betrag.class, anzahlBytes = 14, byteAdresse = 78)
+    @FeldInfo(teildatensatz = 1, nr = 13, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 78)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_VS_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2.java
@@ -153,7 +153,7 @@ public enum Feld220Wagnis2 {
      * Dynamik %-Satz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 23, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 134)
+    @FeldInfo(teildatensatz = 1, nr = 23, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 134)
     DYNAMIK_PROZENT_SATZ,
 
     /**
@@ -192,7 +192,7 @@ public enum Feld220Wagnis2 {
      * kumuliert, incl. aller Dynamiken
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 28, type = Betrag.class, anzahlBytes = 9, byteAdresse = 157)
+    @FeldInfo(teildatensatz = 1, nr = 28, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 157)
     RUECKKAUFSWERT_IN_WAEHRUNGSEINHEITEN,
 
     /**
@@ -244,7 +244,7 @@ public enum Feld220Wagnis2 {
      * Vertraglich vereinbarte Kapitalzahlungssumme zum Ablauf (inkl. Abrufphase)
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 35, type = Betrag.class, anzahlBytes = 9, byteAdresse = 204)
+    @FeldInfo(teildatensatz = 1, nr = 35, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 204)
     KAPITALZAHLUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**
@@ -654,14 +654,14 @@ public enum Feld220Wagnis2 {
      * Jahresrente inkl. Gewinnbeteiligung in WE.
      * (12,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 3, nr = 20, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 158)
+    @FeldInfo(teildatensatz = 3, nr = 20, type = Betrag.class, anzahlBytes = 14, byteAdresse = 158)
     JAHRESRENTE_INKL_GEWINNBETEILIGUNG_IN_WAEHRUNGSEINHEITEN,
     
     /**
      * Kapitalzahlungssumme inkl. Gewinnbeteiligung in WE.
      * (12,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 3, nr = 21, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 158)
+    @FeldInfo(teildatensatz = 3, nr = 21, type = Betrag.class, anzahlBytes = 14, byteAdresse = 158)
     KAPITALZAHLUNGSSUMME_INKL_GEWINNBETEILIGUNG_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2Auszahlungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2Auszahlungen.java
@@ -79,7 +79,7 @@ public enum Feld220Wagnis2Auszahlungen {
      * wurde (NAECHSTE_AUSZAHLUNGSSUMMER_IN_WAEHRUNGSEINHEITEN).
      * </p>
      */
-    @FeldInfo(teildatensatz = 1, nr = 12, type = Betrag.class, anzahlBytes = 9, byteAdresse = 64)
+    @FeldInfo(teildatensatz = 1, nr = 12, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 64)
     NAECHSTE_AUSZAHLUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2Bezugsrechte.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2Bezugsrechte.java
@@ -87,7 +87,7 @@ public enum Feld220Wagnis2Bezugsrechte {
     /**
      * Bezugsrechtanteil im Erlebensfall in Prozent (3,2 Stellen).
      */
-    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 95)
     BEZUGSRECHTANTEIL_IM_ERLEBENSFALL,
 
     /**
@@ -118,7 +118,7 @@ public enum Feld220Wagnis2Bezugsrechte {
      * Bezugsrechtanteil im Todesfall.
      * in Prozent (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 132)
+    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 132)
     BEZUGSRECHTANTEIL_IM_TODESFALL,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld220Wagnis2ZukSummenaenderungen.java
@@ -100,7 +100,7 @@ public enum Feld220Wagnis2ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Todesfalleistung
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 77)
+    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 77)
     TODESFALLAENDERUNGS_PROZENTSATZ,
 
     /**
@@ -108,7 +108,7 @@ public enum Feld220Wagnis2ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfalleistung
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 16, type = Betrag.class, anzahlBytes = 9, byteAdresse = 82)
+    @FeldInfo(teildatensatz = 1, nr = 16, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 82)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_VS_IN_WAEHRUNGSEINHEITEN,
 
     /**
@@ -159,7 +159,7 @@ public enum Feld220Wagnis2ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Jahresrente
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 124)
+    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 124)
     JAHRESRENTENAENDERUNGS_PROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld221Wagnis2ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart2/Feld221Wagnis2ZukSummenaenderungen.java
@@ -81,7 +81,7 @@ public enum Feld221Wagnis2ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfalleistung
      * (12,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 13, type = Betrag.class, anzahlBytes = 14, byteAdresse = 78)
+    @FeldInfo(teildatensatz = 1, nr = 13, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 78)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_VS_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart48/Feld220Wagnis48.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart48/Feld220Wagnis48.java
@@ -143,7 +143,7 @@ public enum Feld220Wagnis48 {
      * Dynamik %-Satz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 118)
+    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 118)
     DYNAMIK_PROZENT_SATZ,
 
     /**
@@ -208,7 +208,7 @@ public enum Feld220Wagnis48 {
      * Anteil an der BUZ-Jahresrente an der VS
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 30, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 158)
+    @FeldInfo(teildatensatz = 1, nr = 30, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 158)
     EINSCHLUSS_PROZENT_SATZ,
 
     /**
@@ -264,7 +264,7 @@ public enum Feld220Wagnis48 {
      * Prozent-Satz, ab dem BUZ-Leistung vereinbart ist
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 37, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 197)
+    @FeldInfo(teildatensatz = 1, nr = 37, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 197)
     BUZ_PROZENT_SATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart48/Feld220Wagnis48Bezugsrechte.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart48/Feld220Wagnis48Bezugsrechte.java
@@ -90,7 +90,7 @@ public enum Feld220Wagnis48Bezugsrechte {
     /**
      * Bezugsrechtanteil im Leistungsfall in Prozent (3,2 Stellen).
      */
-    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 95)
     BEZUGSRECHTANTEIL_IM_LEISTUNGSFALL,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart48/Feld220Wagnis48ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart48/Feld220Wagnis48ZukSummenaenderungen.java
@@ -100,7 +100,7 @@ public enum Feld220Wagnis48ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Jahresrente
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 80)
+    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 80)
     JAHRESRENTENAENDERUNGS_PROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld220Wagnis5.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld220Wagnis5.java
@@ -159,7 +159,7 @@ public enum Feld220Wagnis5 {
      * Dynamik %-Satz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 24, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 128)
+    @FeldInfo(teildatensatz = 1, nr = 24, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 128)
     DYNAMIK_PROZENT_SATZ,
 
     /**
@@ -358,21 +358,21 @@ public enum Feld220Wagnis5 {
      * BfA-Dynamik
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 19, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 192)
+    @FeldInfo(teildatensatz = 2, nr = 19, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 192)
     ANTEILIGER_DYNAMIKPROZENTSATZ,
 
     /**
      * Vereinbarter Dynamikmindestanpassungsprozentsatz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 20, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 197)
+    @FeldInfo(teildatensatz = 2, nr = 20, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 197)
     VEREINBARTER_DYNAMIKMINDESTANPASSUNGSPROZENTSATZ,
 
     /**
      * Vereinbarter Dynamikmaximalanpassungsprozentsatz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 21, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 202)
+    @FeldInfo(teildatensatz = 2, nr = 21, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 202)
     VEREINBARTER_DYNAMIKMAXIMALANPASSUNGSPROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld220Wagnis5Bezugsrechte.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld220Wagnis5Bezugsrechte.java
@@ -88,7 +88,7 @@ public enum Feld220Wagnis5Bezugsrechte {
      * Bezugsrechtanteil im Todesfall.
      * in Prozent (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 95)
     BEZUGSRECHTANTEIL_IM_TODESFALL,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld220Wagnis5ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld220Wagnis5ZukSummenaenderungen.java
@@ -101,7 +101,7 @@ public enum Feld220Wagnis5ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Todesfallleistung
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 77)
+    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 77)
     TODESFALLAENDERUNGS_PROZENTSATZ,
 
     /**
@@ -109,7 +109,7 @@ public enum Feld220Wagnis5ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfallleistung
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 16, type = Betrag.class, anzahlBytes = 9, byteAdresse = 82)
+    @FeldInfo(teildatensatz = 1, nr = 16, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 82)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld221Wagnis5ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart5/Feld221Wagnis5ZukSummenaenderungen.java
@@ -82,7 +82,7 @@ public enum Feld221Wagnis5ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfalleistung
      * (12,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 13, type = Betrag.class, anzahlBytes = 14, byteAdresse = 78)
+    @FeldInfo(teildatensatz = 1, nr = 13, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 78)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart6/Feld220Wagnis6.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart6/Feld220Wagnis6.java
@@ -124,7 +124,7 @@ public enum Feld220Wagnis6 {
      * Dynamik %-Satz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 19, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 106)
+    @FeldInfo(teildatensatz = 1, nr = 19, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 106)
     DYNAMIK_PROZENT_SATZ,
 
     /**
@@ -182,7 +182,7 @@ public enum Feld220Wagnis6 {
      * Anteil an der VS (100% oder 200%)
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 26, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 134)
+    @FeldInfo(teildatensatz = 1, nr = 26, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 134)
     EINSCHLUSS_PROZENT_SATZ,
 
     /**
@@ -329,21 +329,21 @@ public enum Feld220Wagnis6 {
      * BfA-Dynamik
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 19, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 192)
+    @FeldInfo(teildatensatz = 2, nr = 19, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 192)
     ANTEILIGER_DYNAMIKPROZENTSATZ,
 
     /**
      * Vereinbarter Dynamikmindestanpassungsprozentsatz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 20, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 197)
+    @FeldInfo(teildatensatz = 2, nr = 20, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 197)
     VEREINBARTER_DYNAMIKMINDESTANPASSUNGSPROZENTSATZ,
 
     /**
      * Vereinbarter Dynamikmaximalanpassungsprozentsatz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 21, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 202)
+    @FeldInfo(teildatensatz = 2, nr = 21, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 202)
     VEREINBARTER_DYNAMIKMAXIMALANPASSUNGSPROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart6/Feld220Wagnis6Bezugsrechte.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart6/Feld220Wagnis6Bezugsrechte.java
@@ -87,7 +87,7 @@ public enum Feld220Wagnis6Bezugsrechte {
     /**
      * Bezugsrechtanteil im Leistungsfall in Prozent (3,2 Stellen).
      */
-    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 95)
     BEZUGSRECHTANTEIL_IM_LEISTUNGSFALL,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart6/Feld220Wagnis6ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart6/Feld220Wagnis6ZukSummenaenderungen.java
@@ -101,7 +101,7 @@ public enum Feld220Wagnis6ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Unfallleistung
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 80)
+    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 80)
     UNFALLAENDERUNGS_PROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld220Wagnis7.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld220Wagnis7.java
@@ -111,7 +111,7 @@ public enum Feld220Wagnis7 {
      * tarifl. Beitragssumme
      * (9,0 Stelle)
      */
-    @FeldInfo(teildatensatz = 1, nr = 17, type = Betrag.class, anzahlBytes = 9, byteAdresse = 102)
+    @FeldInfo(teildatensatz = 1, nr = 17, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 102)
     BEITRAGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**
@@ -119,13 +119,12 @@ public enum Feld220Wagnis7 {
      * tarifl. VS
      * (9,0 Stelle)
      */
-    @FeldInfo(teildatensatz = 1, nr = 18, type = Betrag.class, anzahlBytes = 9, byteAdresse = 111)
+    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 111)
     TODESFALL_VS_IN_WAEHRUNGSEINHEITEN,
 
     /**
      * Fallende VS.
      * tarifl. VS
-     * (9,0 Stelle)
      */
     @FeldInfo(teildatensatz = 1, nr = 19, type = Zeichen.class, anzahlBytes = 1, byteAdresse = 120)
     FALLENDE_VS,
@@ -215,7 +214,7 @@ public enum Feld220Wagnis7 {
      * Dynamik %-Satz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 31, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 193)
+    @FeldInfo(teildatensatz = 1, nr = 31, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 193)
     DYNAMIK_PROZENT_SATZ,
 
     /**
@@ -281,7 +280,7 @@ public enum Feld220Wagnis7 {
      * kumuliert, incl. aller Dynamiken
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 39, type = Betrag.class, anzahlBytes = 9, byteAdresse = 222)
+    @FeldInfo(teildatensatz = 1, nr = 39, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 222)
     RUECKKAUFSWERT_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld220Wagnis7Bezugsrechte.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld220Wagnis7Bezugsrechte.java
@@ -87,7 +87,7 @@ public enum Feld220Wagnis7Bezugsrechte {
     /**
      * Bezugsrechtanteil im Erlebensfall in Prozent (3,2 Stellen).
      */
-    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 95)
     BEZUGSRECHTANTEIL_IM_ERLEBENSFALL,
 
     /**
@@ -118,7 +118,7 @@ public enum Feld220Wagnis7Bezugsrechte {
      * Bezugsrechtanteil im Todesfall.
      * in Prozent (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 132)
+    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 132)
     BEZUGSRECHTANTEIL_IM_TODESFALL,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld220Wagnis7ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld220Wagnis7ZukSummenaenderungen.java
@@ -101,7 +101,7 @@ public enum Feld220Wagnis7ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Todesfalleistung
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 77)
+    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 77)
     TODESFALLAENDERUNGS_PROZENTSATZ,
 
     /**
@@ -109,7 +109,7 @@ public enum Feld220Wagnis7ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfalleistung
      * (9,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 16, type = Betrag.class, anzahlBytes = 9, byteAdresse = 82)
+    @FeldInfo(teildatensatz = 1, nr = 16, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 82)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**
@@ -160,7 +160,7 @@ public enum Feld220Wagnis7ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Jahresrente
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 121)
+    @FeldInfo(teildatensatz = 1, nr = 22, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 121)
     BEITRAGSSUMMENAENDERUNGS_PROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld221Wagnis7ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart7/Feld221Wagnis7ZukSummenaenderungen.java
@@ -82,7 +82,7 @@ public enum Feld221Wagnis7ZukSummenaenderungen {
      * Absolute Summe der Steigerung bzw. Reduzierung der Todesfalleistung
      * (12,0 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 13, type = Betrag.class, anzahlBytes = 14, byteAdresse = 78)
+    @FeldInfo(teildatensatz = 1, nr = 13, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 78)
     ABSOLUTE_TODESFALLAENDERUNGSSUMME_VS_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9.java
@@ -150,7 +150,7 @@ public enum Feld220Wagnis9 {
      * Dynamik %-Satz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 23, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 134)
+    @FeldInfo(teildatensatz = 1, nr = 23, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 134)
     DYNAMIK_PROZENT_SATZ,
 
     /**
@@ -502,21 +502,21 @@ public enum Feld220Wagnis9 {
      * z. B.: 100,00 = volle absolute BfA-Dynamik
      * 50,00 = halbe absolute BfA-Dynamik (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 26, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 211)
+    @FeldInfo(teildatensatz = 2, nr = 26, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 211)
     ANTEILIGER_DYNAMIKPROZENTSATZ,
 
     /**
      * Vereinbarter Dynamikmindestanpassungsprozentsatz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 27, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 216)
+    @FeldInfo(teildatensatz = 2, nr = 27, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 216)
     VEREINBARTER_DYNAMIKMINDESTANPASSUNGSPROZENTSATZ,
 
     /**
      * Vereinbarter Dynamikmaximalanpassungsprozentsatz.
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 2, nr = 28, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 221)
+    @FeldInfo(teildatensatz = 2, nr = 28, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 221)
     VEREINBARTER_DYNAMIKMAXIMALANPASSUNGSPROZENTSATZ,
 
     /**
@@ -732,14 +732,14 @@ public enum Feld220Wagnis9 {
      * Jahresrente inkl. Gewinnbeteiligung in WE.
      * (12,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 4, nr = 15, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 4, nr = 15, type = Betrag.class, anzahlBytes = 14, byteAdresse = 95)
     JAHRESRENTE_INKL_GEWINNBETEILIGUNG_IN_WAEHRUNGSEINHEITEN,
     
     /**
      * Kapitalzahlungssumme inkl. Gewinnbeteiligung in WE.
      * (12,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 4, nr = 16, type = NumFeld.class, anzahlBytes = 14, byteAdresse = 109)
+    @FeldInfo(teildatensatz = 4, nr = 16, type = Betrag.class, anzahlBytes = 14, byteAdresse = 109)
     KAPITALZAHLUNGSSUMME_INKL_GEWINNBETEILIGUNG_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9Auszahlungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9Auszahlungen.java
@@ -74,7 +74,7 @@ public enum Feld220Wagnis9Auszahlungen {
      * wurde (NAECHSTE_AUSZAHLUNGSSUMMER_IN_WAEHRUNGSEINHEITEN).
      * </p>
      */
-    @FeldInfo(teildatensatz = 1, nr = 12, type = Betrag.class, anzahlBytes = 9, byteAdresse = 64)
+    @FeldInfo(teildatensatz = 1, nr = 12, type = NumFeld.class, anzahlBytes = 9, byteAdresse = 64)
     NAECHSTE_AUSZAHLUNGSSUMME_IN_WAEHRUNGSEINHEITEN,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9Bezugsrechte.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9Bezugsrechte.java
@@ -84,7 +84,7 @@ public enum Feld220Wagnis9Bezugsrechte {
     /**
      * Bezugsrechtanteil im Erlebensfall in Prozent (3,2 Stellen).
      */
-    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 95)
+    @FeldInfo(teildatensatz = 1, nr = 14, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 95)
     BEZUGSRECHTANTEIL_IM_ERLEBENSFALL,
 
     /**
@@ -115,7 +115,7 @@ public enum Feld220Wagnis9Bezugsrechte {
      * Bezugsrechtanteil im Todesfall.
      * in Prozent (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 132)
+    @FeldInfo(teildatensatz = 1, nr = 18, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 132)
     BEZUGSRECHTANTEIL_IM_TODESFALL,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9ZukSummenaenderungen.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld220Wagnis9ZukSummenaenderungen.java
@@ -97,7 +97,7 @@ public enum Feld220Wagnis9ZukSummenaenderungen {
      * Konstanter Prozentsatz der Steigerung bzw. Reduzierung der Todesfalleistung
      * (3,2 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, anzahlBytes = 5, byteAdresse = 80)
+    @FeldInfo(teildatensatz = 1, nr = 15, type = NumFeld.class, nachkommaStellen = 2, anzahlBytes = 5, byteAdresse = 80)
     TODESFALLAENDERUNGS_PROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld230.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte10/wagnisart9/Feld230.java
@@ -119,7 +119,7 @@ public enum Feld230 {
      * Prozentualer Anteil des Beitrags mit dem dieser Fonds aktuell bespart wird
      * (3,4 Stellen)
      */
-    @FeldInfo(teildatensatz = 1, nr = 19, type = NumFeld.class, anzahlBytes = 7, byteAdresse = 167)
+    @FeldInfo(teildatensatz = 1, nr = 19, type = NumFeld.class, nachkommaStellen = 4, anzahlBytes = 7, byteAdresse = 167)
     PROZENTSATZ,
 
     /**

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte110/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte110/Feld220.java
@@ -20,7 +20,7 @@ public enum Feld220 {
 
     /** Feld 1 - 7 sind fuer jeden (Teil-)Datensatz identisch. */
     @FelderInfo(
-            sparte = 30,
+            sparte = 110,
             teildatensatz = 1,
             type = Feld1bis7.class)
     INTRO1,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte110/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte110/Feld220.java
@@ -3,6 +3,7 @@ package gdv.xport.satz.feld.sparte110;
 import gdv.xport.annotation.FeldInfo;
 import gdv.xport.annotation.FelderInfo;
 import gdv.xport.feld.AlphaNumFeld;
+import gdv.xport.feld.Betrag;
 import gdv.xport.feld.Datum;
 import gdv.xport.feld.NumFeld;
 import gdv.xport.satz.feld.common.Feld1bis7;
@@ -256,9 +257,8 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 24,
-            type = NumFeld.class,
+            type = Betrag.class,
             anzahlBytes = 12,
-            nachkommaStellen = 2,
             byteAdresse = 167
     )
     BEITRAG,
@@ -285,9 +285,8 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 26,
-            type = NumFeld.class,
+            type = Betrag.class,
             anzahlBytes = 12,
-            nachkommaStellen = 2,
             byteAdresse = 183 )
     SELBSTBETEILIGUNG_IN_WAEHRUNGSEINHEITEN,
 

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte130/Feld210.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte130/Feld210.java
@@ -21,7 +21,7 @@ public enum Feld210 {
 
     /** Feld 1 - 7 sind fuer jeden (Teil-)Datensatz identisch. */
     @FelderInfo(
-            sparte = 30,
+            sparte = 130,
             teildatensatz = 1,
             type = Feld1bis7.class)
     INTRO1,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte130/Feld210.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte130/Feld210.java
@@ -3,6 +3,7 @@ package gdv.xport.satz.feld.sparte130;
 import gdv.xport.annotation.FeldInfo;
 import gdv.xport.annotation.FelderInfo;
 import gdv.xport.feld.AlphaNumFeld;
+import gdv.xport.feld.Betrag;
 import gdv.xport.feld.Datum;
 import gdv.xport.feld.NumFeld;
 import gdv.xport.feld.Zeichen;
@@ -181,8 +182,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 18,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 12,
             byteAdresse = 145)
     ZUSCHLAGSBETRAG_IN_WAEHRUNGSEINHEITEN,
@@ -195,8 +195,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 19,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 12,
             byteAdresse = 157)
     ABSCHLAGSBETRAG_IN_WAEHRUNGSEINHEITEN,
@@ -223,7 +222,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 21,
-            type = NumFeld.class,
+            type = Betrag.class,
             nachkommaStellen = 2,
             anzahlBytes = 12,
             byteAdresse = 181)
@@ -461,6 +460,7 @@ public enum Feld210 {
             teildatensatz = 1,
             nr = 39,
             type = NumFeld.class,
+            nachkommaStellen = 2,
             anzahlBytes = 4,
             byteAdresse = 232)
     LAUFZEITRABATT_IN_PROZENT,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte140/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte140/Feld220.java
@@ -283,7 +283,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 27,
-            type = NumFeld.class,
+            type = Betrag.class,
             anzahlBytes = 12,
             nachkommaStellen = 2,
             byteAdresse = 166)
@@ -516,7 +516,7 @@ public enum Feld220 {
             nachkommaStellen = 2,
             anzahlBytes = 4,
             byteAdresse = 150)
-    PRÄMIENFAKTOR,
+    PRAEMIENFAKTOR,
     
     /**
      * Beitrag aktuell in Währungseinheiten

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte140/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte140/Feld220.java
@@ -22,7 +22,7 @@ public enum Feld220 {
 
     /** Feld 1 - 7 sind fuer jeden (Teil-)Datensatz identisch. */
     @FelderInfo(
-            sparte = 30,
+            sparte = 140,
             teildatensatz = 1,
             type = Feld1bis7.class)
     INTRO1,
@@ -332,7 +332,7 @@ public enum Feld220 {
 
     /** Feld 1 - 7 sind fuer jeden (Teil-)Datensatz identisch. */
     @FelderInfo(
-            sparte = 30,
+            sparte = 140,
             teildatensatz = 2,
             type = Feld1bis7.class)
     INTRO2,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld210.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld210.java
@@ -160,6 +160,7 @@ public enum Feld210 {
             teildatensatz = 1,
             nr = 16,
             type = NumFeld.class,
+            nachkommaStellen = 3,
             anzahlBytes = 5,
             byteAdresse = 75)
     DYNAMIK_IN_PROZENT,
@@ -261,6 +262,7 @@ public enum Feld210 {
             teildatensatz = 1,
             nr = 24,
             type = NumFeld.class,
+            nachkommaStellen = 2,
             anzahlBytes = 5,
             byteAdresse = 132)
     ABSCHLUSSPROVISION,
@@ -274,6 +276,7 @@ public enum Feld210 {
             teildatensatz = 1,
             nr = 25,
             type = NumFeld.class,
+            nachkommaStellen = 2,
             anzahlBytes = 5,
             byteAdresse = 137)
     FOLGEPROVISION,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld220.java
@@ -520,6 +520,7 @@ public enum Feld220 {
             teildatensatz = 2,
             nr = 17,
             type = NumFeld.class,
+            nachkommaStellen = 1,
             anzahlBytes = 3,
             byteAdresse = 91)
     BEGINN_TAGEGELD1_AB_TAG,
@@ -560,6 +561,7 @@ public enum Feld220 {
             teildatensatz = 2,
             nr = 20,
             type = NumFeld.class,
+            nachkommaStellen = 1,
             anzahlBytes = 3,
             byteAdresse = 108)
     BEGINN_TAGEGELD2_AB_TAG,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld221.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld221.java
@@ -72,8 +72,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 10,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 50
     )
@@ -85,8 +84,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 11,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 64
     )
@@ -98,8 +96,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 12,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 10,
             byteAdresse = 78
     )
@@ -111,8 +108,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 13,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 10,
             byteAdresse = 88
     )
@@ -124,8 +120,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 14,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 10,
             byteAdresse = 98
     )
@@ -137,8 +132,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 15,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 10,
             byteAdresse = 108
     )
@@ -150,8 +144,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 16,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 118
     )
@@ -163,8 +156,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 17,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 132
     )
@@ -176,8 +168,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 18,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 146
     )
@@ -189,8 +180,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 19,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 160
     )
@@ -202,8 +192,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 20,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 174
     )
@@ -215,8 +204,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 21,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 188
     )
@@ -274,8 +262,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 3,
             nr = 9,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 44
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld230.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte30/Feld230.java
@@ -194,7 +194,7 @@ public enum Feld230 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 19,
-            type = NumFeld.class,
+            type = Betrag.class,
             nachkommaStellen = 2,
             anzahlBytes = 6,
             byteAdresse = 126)

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte40/Feld210.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte40/Feld210.java
@@ -134,7 +134,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 14,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 72)
     DECKUNGSSUMME_1_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -174,7 +174,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 17,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 85)
     DECKUNGSSUMME_2_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -214,7 +214,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 20,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 98)
     DECKUNGSSUMME_3_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -254,7 +254,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 23,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 111)
     DECKUNGSSUMME_4_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -400,6 +400,7 @@ public enum Feld210 {
             teildatensatz = 1,
             nr = 32,
             type = NumFeld.class,
+            nachkommaStellen = 2,
             anzahlBytes = 5,
             byteAdresse = 166)
     ABSCHLUSSPROVISION,
@@ -415,6 +416,7 @@ public enum Feld210 {
             teildatensatz = 1,
             nr = 33,
             type = NumFeld.class,
+            nachkommaStellen = 2,
             anzahlBytes = 5,
             byteAdresse = 171)
     FOLGEPROVISION,
@@ -472,6 +474,7 @@ public enum Feld210 {
             teildatensatz = 1,
             nr = 37,
             type = NumFeld.class,
+            nachkommaStellen = 2,
             anzahlBytes = 4,
             byteAdresse = 180)
     LAUFZEITRABATT_IN_PROZENT,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte40/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte40/Feld220.java
@@ -95,7 +95,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 12,
-            type = Zeichen.class,
+            type = NumFeld.class,
             anzahlBytes = 1,
             byteAdresse = 55)
     MENGENSCHLUESSEL,
@@ -107,7 +107,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 13,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 12,
             byteAdresse = 56)
     WAGNISMENGE,
@@ -220,7 +220,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 21,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 133)
     DECKUNGSSUMME_1_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -246,7 +246,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 23,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 143)
     DECKUNGSSUMME_2_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -272,7 +272,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 25,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 153)
     DECKUNGSSUMME_3_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -298,7 +298,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 27,
-            type = Betrag.class,
+            type = NumFeld.class,
             anzahlBytes = 9,
             byteAdresse = 163)
     DECKUNGSSUMME_4_IN_TAUSEND_WAEHRUNGSEINHEITEN,
@@ -351,6 +351,7 @@ public enum Feld220 {
             teildatensatz = 1,
             nr = 30,
             type = NumFeld.class,
+            nachkommaStellen = 2,
             anzahlBytes = 5,
             byteAdresse = 174)
     ERHOEHUNGSSATZ_8_III_AHB,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte51/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte51/Feld220.java
@@ -221,8 +221,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 22,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 6,
             byteAdresse = 128
     )
@@ -234,8 +233,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 23,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 6,
             byteAdresse = 134
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte51/Feld221.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte51/Feld221.java
@@ -47,8 +47,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 8,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 43
     )
@@ -60,8 +59,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 9,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 57
     )
@@ -73,8 +71,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 10,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 71
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte510/Feld210.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte510/Feld210.java
@@ -22,7 +22,7 @@ public enum Feld210 {
 
     /** Feld 1 - 7 sind fuer jeden (Teil-)Datensatz identisch. */
     @FelderInfo(
-            sparte = 30,
+            sparte = 510,
             teildatensatz = 1,
             type = Feld1bis7.class)
     INTRO1,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte510/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte510/Feld220.java
@@ -22,7 +22,7 @@ public enum Feld220 {
 
     /** Feld 1 - 7 sind fuer jeden (Teil-)Datensatz identisch. */
     @FelderInfo(
-            sparte = 30,
+            sparte = 510,
             teildatensatz = 1,
             type = Feld1bis7.class)
     INTRO1,

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte52/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte52/Feld220.java
@@ -183,8 +183,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 19,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 6,
             byteAdresse = 101
     )
@@ -196,8 +195,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 20,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 6,
             byteAdresse = 107
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte53/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte53/Feld220.java
@@ -21,6 +21,7 @@ package gdv.xport.satz.feld.sparte53;
 import gdv.xport.annotation.FeldInfo;
 import gdv.xport.annotation.FelderInfo;
 import gdv.xport.feld.AlphaNumFeld;
+import gdv.xport.feld.Betrag;
 import gdv.xport.feld.Datum;
 import gdv.xport.feld.NumFeld;
 import gdv.xport.feld.Zeichen;
@@ -150,8 +151,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 16,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 6,
             byteAdresse = 91
     )
@@ -163,8 +163,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 17,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 6,
             byteAdresse = 97
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte55/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte55/Feld220.java
@@ -188,6 +188,7 @@ public enum Feld220 {
             teildatensatz = 1,
             nr = 19,
             type = NumFeld.class,
+            nachkommaStellen = 4,
             anzahlBytes = 3,
             byteAdresse = 154)
     BEITRAGSSATZ,
@@ -198,7 +199,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 20,
-            type = Betrag.class,
+            type = NumFeld.class,
             nachkommaStellen = 1,
             anzahlBytes = 8,
             byteAdresse = 157
@@ -516,10 +517,9 @@ public enum Feld220 {
      */
     @FeldInfo(
             teildatensatz = 2, 
-            nr = 15, type = 
-            NumFeld.class, 
+            nr = 15,
+            type = Betrag.class, 
             anzahlBytes = 12, 
-            nachkommaStellen = 2, 
             byteAdresse = 170)
     SELBSTBETEILIGUNG_IN_WAEHRUNGSEINHEITEN_MIND,
 
@@ -529,9 +529,8 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 2, 
             nr = 16, 
-            type = NumFeld.class, 
+            type = Betrag.class, 
             anzahlBytes = 12, 
-            nachkommaStellen = 2, 
             byteAdresse = 182)
     SELBSTBETEILIGUNG_IN_WAEHRUNGSEINHEITEN_MAX,
 

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte55/Feld221.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte55/Feld221.java
@@ -63,8 +63,8 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 9,
-            type = Betrag.class,
-            nachkommaStellen = 2,
+            type = NumFeld.class,
+            nachkommaStellen = 1,
             anzahlBytes = 12,
             byteAdresse = 55
     )
@@ -77,7 +77,6 @@ public enum Feld221 {
             teildatensatz = 1,
             nr = 10,
             type = Betrag.class,
-            nachkommaStellen = 2,
             anzahlBytes = 12,
             byteAdresse = 67
     )
@@ -90,7 +89,6 @@ public enum Feld221 {
             teildatensatz = 1,
             nr = 11,
             type = Betrag.class,
-            nachkommaStellen = 2,
             anzahlBytes = 12,
             byteAdresse = 79
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte59/Feld221.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte59/Feld221.java
@@ -22,6 +22,7 @@ import gdv.xport.annotation.FeldInfo;
 import gdv.xport.annotation.FelderInfo;
 import gdv.xport.feld.AlphaNumFeld;
 import gdv.xport.feld.Betrag;
+import gdv.xport.feld.NumFeld;
 import gdv.xport.feld.Zeichen;
 import gdv.xport.satz.feld.common.Feld1bis7;
 
@@ -62,8 +63,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 9,
-            type = Betrag.class,
-            nachkommaStellen = 2,
+            type = NumFeld.class,
             anzahlBytes = 12,
             byteAdresse = 57
     )
@@ -75,8 +75,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 10,
-            type = Betrag.class,
-            nachkommaStellen = 2,
+            type = NumFeld.class,
             anzahlBytes = 12,
             byteAdresse = 69
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte70/Feld210.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte70/Feld210.java
@@ -176,7 +176,7 @@ public enum Feld210 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 22,
-            type = Datum.class,
+            type = NumFeld.class,
             anzahlBytes = 2,
             byteAdresse = 110
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte70/Feld220.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte70/Feld220.java
@@ -278,7 +278,7 @@ public enum Feld220 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 27,
-            type = Zeichen.class,
+            type = NumFeld.class,
             anzahlBytes = 1,
             byteAdresse = 170
     )

--- a/lib/src/main/java/gdv/xport/satz/feld/sparte70/Feld221.java
+++ b/lib/src/main/java/gdv/xport/satz/feld/sparte70/Feld221.java
@@ -83,8 +83,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 1,
             nr = 11,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 14,
             byteAdresse = 54
     )
@@ -154,8 +153,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 11,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 12,
             byteAdresse = 54
     )
@@ -167,8 +165,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 12,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 12,
             byteAdresse = 66
     )
@@ -180,8 +177,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 13,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 12,
             byteAdresse = 78
     )
@@ -193,8 +189,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 14,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 12,
             byteAdresse = 90
     )
@@ -206,8 +201,7 @@ public enum Feld221 {
     @FeldInfo(
             teildatensatz = 2,
             nr = 15,
-            type = NumFeld.class,
-            nachkommaStellen = 2,
+            type = Betrag.class,
             anzahlBytes = 12,
             byteAdresse = 102
     )

--- a/lib/src/test/java/gdv/xport/satz/AbstractSatzTest.java
+++ b/lib/src/test/java/gdv/xport/satz/AbstractSatzTest.java
@@ -37,8 +37,7 @@ import org.junit.Test;
 import patterntesting.runtime.junit.ObjectTester;
 
 /**
- * Hier setzen wir eine Standard-Konfiguration auf, die wir in den
- * verschiedenen JUnit-Tests verwenden.
+ * Hier setzen wir eine Standard-Konfiguration auf, die wir in den verschiedenen JUnit-Tests verwenden.
  *
  * @author oliver
  * @since 09.10.2009
@@ -65,10 +64,8 @@ abstract public class AbstractSatzTest {
         Config.setVUNummer(VU_NUMMER);
     }
 
-
     /**
-     * Die Satzart ist im ersten Feld (Byte 1 - 4) enthalten und ist in jedem
-     * Satz vorhanden (auch Vorsatz und Nachsatz).
+     * Die Satzart ist im ersten Feld (Byte 1 - 4) enthalten und ist in jedem Satz vorhanden (auch Vorsatz und Nachsatz).
      */
     @Test
     public void testSatzart() {
@@ -92,7 +89,7 @@ abstract public class AbstractSatzTest {
     /**
      * @param satz Satz
      * @param startByte beginnend bei 1
-     * @param endByte   beginnend bei 1
+     * @param endByte beginnend bei 1
      * @param expected erwarteter Export-String
      * @param expectedLength erwartete Laenge
      * @throws IOException sollte bei StringWriter eigentlich nicht vorkommen
@@ -135,8 +132,7 @@ abstract public class AbstractSatzTest {
     }
 
     /**
-     * Setzt fuer den uebergebenen Satz die normalen Felder mit einem Wert,
-     * damit einfache Test-Daten fuer die einzelnen Tests vorhanden sind.
+     * Setzt fuer den uebergebenen Satz die normalen Felder mit einem Wert, damit einfache Test-Daten fuer die einzelnen Tests vorhanden sind.
      *
      * @param satz the new up
      */
@@ -149,10 +145,15 @@ abstract public class AbstractSatzTest {
     private static void setUp(final Teildatensatz tds) {
         for (Feld feld : tds.getFelder()) {
             if ((feld.getByteAdresse() > 42) && (feld.getByteAdresse() < 256)) {
-                feld.setInhalt('1');
+                // TODO hier ist es eventuell noetig die Logik aus Satz.readSatznummer zu uebernehmen
+                // TODO Alternativ die Methode so aendern, dass sie den Index der Satznummer rausgibt und hier dann nutzen
+                if (tds.getSatzart() == 210 && tds.getSparte() == 130 && feld.getByteAdresse() == 251) {
+                    // 0210.130 Satznummer an Adresse 251
+                } else {
+                    feld.setInhalt('1');
+                }
             }
         }
     }
 
 }
-


### PR DESCRIPTION
* Fix für den in #27 fehlschlagenden Test: Der Setup hat die Satznummer an Byte 251 überschrieben
* Diverse FeldInfos in Enums korrigiert (meist in Bezug auf Datum oder Gleitkommazahlen/Beträge)