### PR TITLE
Fix #22 Teildatensatz.getSafe wirf IllegalArgumentException

### DIFF
--- a/lib/src/main/java/gdv/xport/satz/Satz.java
+++ b/lib/src/main/java/gdv/xport/satz/Satz.java
@@ -285,7 +285,7 @@ public abstract class Satz implements Cloneable {
     public void set(final Bezeichner name, final String value) {
         boolean found = false;
         for (int i = 0; i < teildatensatz.length; i++) {
-            Feld x = teildatensatz[i].getFeld(name);
+            Feld x = teildatensatz[i].getFeldSafe(name);
             if (x != Feld.NULL_FELD) {
                 x.setInhalt(value);
                 found = true;
@@ -380,7 +380,7 @@ public abstract class Satz implements Cloneable {
 	public Feld getFeld(final Enum<?> feld) throws IllegalArgumentException {
 		for (int i = 0; i < teildatensatz.length; i++) {
 			try {
-				Feld x = teildatensatz[i].getFeld(feld);
+				Feld x = teildatensatz[i].getFeldSafe(feld);
 				if (x != Feld.NULL_FELD) {
 					return x;
 				}
@@ -393,6 +393,23 @@ public abstract class Satz implements Cloneable {
 		        + " vorhanden!");
 	}
 
+    /**
+     * Liefert das gewuenschte Feld oder {@link Feld#NULL_FELD}, wenn nicht
+     * vorhanden. Allerdings wird nur der Name des Feldes benutzt, um das Feld zu
+     * bestimmen. Dazu werden auch die Konstanten in
+     * {@link gdv.xport.feld.Bezeichner} verwendet.
+     *
+     * @param feld gewuenschtes Feld-Element
+     * @return das gesuchte Feld
+     */
+    public Feld getFeldSafe(final Enum<?> feld) {
+        try {
+            return getFeld(feld);
+        } catch (IllegalArgumentException ex) {
+            return Feld.NULL_FELD;
+        }
+    }
+
 	/**
 	 * Liefert das gewuenschte Feld falls vorhanden oder null.
 	 *
@@ -401,7 +418,7 @@ public abstract class Satz implements Cloneable {
 	 */
 	public Feld containsFeld(final String name) {
 		for (int i = 0; i < teildatensatz.length; i++) {
-			Feld x = teildatensatz[i].getFeld(name);
+			Feld x = teildatensatz[i].getFeldSafe(name);
 			if (x != Feld.NULL_FELD) {
 				return x;
 			}
@@ -417,9 +434,20 @@ public abstract class Satz implements Cloneable {
 	 * @return das gesuchte Feld
 	 * @throws IllegalArgumentException falls es das Feld nicht gibt
 	 */
-	public Feld getFeld(final String name) {
+	public Feld getFeld(final String name) throws IllegalArgumentException {
 		return this.getFeld(new Bezeichner(name));
 	}
+	
+    /**
+     * Liefert das gewuenschte Feld oder {@link Feld#NULL_FELD}, wenn nicht
+     * vorhanden.
+     *
+     * @param name gewuenschter Bezeichner des Feldes
+     * @return das gesuchte Feld
+     */
+    public Feld getFeldSafe(final String name) {
+        return this.getFeldSafe(new Bezeichner(name));
+    }
 
     /**
      * Fraegt ab, ob das entsprechende Feld vorhanden ist.
@@ -443,9 +471,9 @@ public abstract class Satz implements Cloneable {
      * @return das gesuchte Feld
      * @throws IllegalArgumentException falls es das Feld nicht gibt
      */
-    public Feld getFeld(final Bezeichner bezeichner) {
+    public Feld getFeld(final Bezeichner bezeichner) throws IllegalArgumentException {
         for (int i = 0; i < teildatensatz.length; i++) {
-            Feld x = teildatensatz[i].getFeld(bezeichner);
+            Feld x = teildatensatz[i].getFeldSafe(bezeichner);
             if (x != Feld.NULL_FELD) {
                 return x;
             }
@@ -455,13 +483,30 @@ public abstract class Satz implements Cloneable {
     }
 
     /**
+     * Liefert das gewuenschte Feld oder {@link Feld#NULL_FELD}, wenn nicht
+     * vorhanden.
+     *
+     * @param bezeichner gewuenschter Bezeichner des Feldes
+     * @return das gesuchte Feld
+     * @throws IllegalArgumentException falls es das Feld nicht gibt
+     */
+    public Feld getFeldSafe(final Bezeichner bezeichner) {
+        try {
+            return getFeld(bezeichner);
+        } catch (IllegalArgumentException ex) {
+            return Feld.NULL_FELD;
+        }
+    }
+
+    /**
      * Liefert den Inhalt des gewuenschten Feldes.
      *
      * @param bezeichner gewuenschter Bezeichner des Feldes
      * @return Inhalt des Feldes (getrimmt, d.h. ohne Leerzeichen am Ende)
      * @since 2.0
+     * @throws IllegalArgumentException falls es das Feld nicht gibt
      */
-    public final String getFeldInhalt(final Bezeichner bezeichner) {
+    public final String getFeldInhalt(final Bezeichner bezeichner) throws IllegalArgumentException {
         return this.getFeld(bezeichner).getInhalt().trim();
     }
 
@@ -471,9 +516,10 @@ public abstract class Satz implements Cloneable {
      * @param name gewuenschter Bezeichner des Feldes
      * @return Inhalt des Feldes (getrimmt, d.h. ohne Leerzeichen am Ende)
      * @since 0.3
+     * @throws IllegalArgumentException falls es das Feld nicht gibt
 	 * @deprecated mit 2.0 durch {@link #getFeldInhalt(Bezeichner)} abgeloest
      */
-    public final String getFeldInhalt(final String name) {
+    public final String getFeldInhalt(final String name) throws IllegalArgumentException {
         return this.getFeld(name).getInhalt().trim();
     }
 
@@ -483,9 +529,10 @@ public abstract class Satz implements Cloneable {
      * @param bezeichner gewuenschter Bezeichner des Feldes
      * @param nr Nummer des Teildatensatzes (1, 2, ...)
      * @return NULL_FELD, falls das angegebene Feld nicht gefunden wird
+     * @throws IllegalArgumentException falls es das Feld nicht gibt
      * @since 2.0
      */
-	public final Feld getFeld(final Bezeichner bezeichner, final int nr) {
+	public final Feld getFeld(final Bezeichner bezeichner, final int nr) throws IllegalArgumentException {
 	    return getFeld(bezeichner.getName(), nr);
 	}
 
@@ -495,9 +542,10 @@ public abstract class Satz implements Cloneable {
 	 * @param name gewuenschter Bezeichner des Feldes
 	 * @param nr Nummer des Teildatensatzes (1, 2, ...)
 	 * @return NULL_FELD, falls das angegebene Feld nicht gefunden wird
+     * @throws IllegalArgumentException falls es das Feld nicht gibt
 	 * @since 0.2
 	 */
-	public final Feld getFeld(final String name, final int nr) {
+	public final Feld getFeld(final String name, final int nr) throws IllegalArgumentException {
 		assert (0 < nr) && (nr <= teildatensatz.length) : nr + " liegt ausserhalb des Bereichs";
 		return teildatensatz[nr - 1].getFeld(name);
 	}
@@ -508,9 +556,10 @@ public abstract class Satz implements Cloneable {
 	 * @param name gewuenschter Bezeichner des Feldes
 	 * @param nr Nummer des Teildatensatzes (1, 2, ...)
 	 * @return Inhalt des Feldes (getrimmt, d.h. ohne Leerzeichen am Ende)
+     * @throws IllegalArgumentException falls es das Feld nicht gibt
 	 * @since 0.3
 	 */
-	public final String getFeldInhalt(final String name, final int nr) {
+	public final String getFeldInhalt(final String name, final int nr) throws IllegalArgumentException {
 		return this.getFeld(name, nr).getInhalt().trim();
 	}
 
@@ -576,7 +625,7 @@ public abstract class Satz implements Cloneable {
 	 * @return true, falls Sparten-Feld vorhanden ist
 	 */
 	public boolean hasSparte() {
-	    Feld sparte = this.getFeld(Feld1bis7.SPARTE);
+	    Feld sparte = this.getFeldSafe(Feld1bis7.SPARTE);
 	    return (sparte != Feld.NULL_FELD) && !sparte.isEmpty();
 	}
 
@@ -1058,7 +1107,7 @@ public abstract class Satz implements Cloneable {
     }
 
     private static void setSparteFor(final Teildatensatz tds, final int sparte) {
-        Feld spartenFeld = tds.getFeld(Feld1bis7.SPARTE);
+        Feld spartenFeld = tds.getFeldSafe(Feld1bis7.SPARTE);
         if (spartenFeld == Feld.NULL_FELD) {
             spartenFeld = new NumFeld((SPARTE), 3, 11);
             tds.add(spartenFeld);

--- a/lib/src/main/java/gdv/xport/satz/Teildatensatz.java
+++ b/lib/src/main/java/gdv/xport/satz/Teildatensatz.java
@@ -275,7 +275,8 @@ public class Teildatensatz extends Satz {
     public Feld getFeld(final Bezeichner bezeichner) {
         Feld found = datenfelder.get(bezeichner);
         if (found == null) {
-            return Feld.NULL_FELD;
+            throw new IllegalArgumentException("Feld \"" + bezeichner + "\" nicht in " + this.toShortString()
+                    + " vorhanden!");
         } else {
             return found;
         }

--- a/lib/src/test/java/gdv/xport/satz/SatzTest.java
+++ b/lib/src/test/java/gdv/xport/satz/SatzTest.java
@@ -18,6 +18,8 @@
 
 package gdv.xport.satz;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -25,6 +27,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,6 +53,7 @@ import gdv.xport.satz.feld.Feld200;
 import gdv.xport.satz.feld.MetaFeldInfo;
 import gdv.xport.satz.feld.common.Feld1bis7;
 import gdv.xport.satz.feld.sparte10.Feld220Wagnis0;
+import gdv.xport.satz.feld.sparte10.wagnisart13.Feld221Wagnis13ZukSummenaenderungen;
 import gdv.xport.satz.feld.sparte53.Feld220;
 import gdv.xport.satz.model.SatzX;
 import gdv.xport.util.SatzFactory;
@@ -134,7 +138,77 @@ public final class SatzTest extends AbstractSatzTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void testGetFeld() {
-        Feld f = satz.getFeld("hemmernet");
+        try {
+            satz.getFeld("hemmernet");
+            fail("IllegalArgumentException bei fehlendem Feld erwartet");
+        } catch (IllegalArgumentException ex) {
+            assertThat("Exception sollte Bezeichner und Satzart beschreiben", ex.getMessage(),
+                    allOf(containsString("Hemmernet"), containsString("Satzart 0123")));
+            throw ex;
+        }
+    }
+    
+    /**
+     * Test method for {@link gdv.xport.satz.Satz#getFeldSafe(java.lang.String)}.
+     * Fuer ein Feld, das nicht existiert, wird bei diesem Aufruf
+     * {@link Feld#NULL_FELD} erwartet.
+     */
+    public void testGetFeldSafe() {
+        Feld f = satz.getFeldSafe("hemmernet");
+        assertSame(Feld.NULL_FELD, f);
+    }
+    
+    /**
+     * Test method for {@link gdv.xport.satz.Satz#getFeld(java.lang.String)}.
+     * Fuer ein Feld, das nicht existiert, wird nicht mehr NULL_FELD als
+     * Ergebnis erwartet sondern eine IllegalArgumentException.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetFeldBezeichner() {
+        try {
+            satz.getFeld(new Bezeichner("hemmernet"));
+            fail("IllegalArgumentException bei fehlendem Feld erwartet");
+        } catch (IllegalArgumentException ex) {
+            assertThat("Exception sollte Bezeichner und Satzart beschreiben", ex.getMessage(),
+                    allOf(containsString("Hemmernet"), containsString("Satzart 0123")));
+            throw ex;
+        }
+    }
+    
+    /**
+     * Test method for {@link gdv.xport.satz.Satz#getFeldSafe(java.lang.String)}.
+     * Fuer ein Feld, das nicht existiert, wird bei diesem Aufruf
+     * {@link Feld#NULL_FELD} erwartet.
+     */
+    public void testGetFeldSafeBezeichner() {
+        Feld f = satz.getFeldSafe(new Bezeichner("hemmernet"));
+        assertSame(Feld.NULL_FELD, f);
+    }
+    
+    /**
+     * Test method for {@link gdv.xport.satz.Satz#getFeld(java.lang.String)}.
+     * Fuer ein Feld, das nicht existiert, wird nicht mehr NULL_FELD als
+     * Ergebnis erwartet sondern eine IllegalArgumentException.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetFeldEnum() {
+        try {
+            satz.getFeld(Feld221Wagnis13ZukSummenaenderungen.ANFAENGLICHE_ERLEBENSFALL_VS_IN_WAEHRUNGSEINHEITEN);
+            fail("IllegalArgumentException bei fehlendem Feld erwartet");
+        } catch (IllegalArgumentException ex) {
+            assertThat("Exception sollte Bezeichner und Satzart beschreiben", ex.getMessage(),
+                    allOf(containsString("ANFAENGLICHE_ERLEBENSFALL_VS_IN_WAEHRUNGSEINHEITEN"), containsString("Satzart 0123")));
+            throw ex;
+        }
+    }
+    
+    /**
+     * Test method for {@link gdv.xport.satz.Satz#getFeldSafe(java.lang.String)}.
+     * Fuer ein Feld, das nicht existiert, wird bei diesem Aufruf
+     * {@link Feld#NULL_FELD} erwartet.
+     */
+    public void testGetFeldSafeEnum() {
+        Feld f = satz.getFeldSafe(Feld221Wagnis13ZukSummenaenderungen.ANFAENGLICHE_ERLEBENSFALL_VS_IN_WAEHRUNGSEINHEITEN);
         assertSame(Feld.NULL_FELD, f);
     }
 

--- a/lib/src/test/java/gdv/xport/satz/TeildatensatzTest.java
+++ b/lib/src/test/java/gdv/xport/satz/TeildatensatzTest.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.*;
 
 /**
@@ -124,7 +126,7 @@ public class TeildatensatzTest extends AbstractSatzTest {
      * erweiterte {@link Bezeichner}-Klasse gab es Probleme mit dem Loeschen
      * von Feldern.
      */
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testRemove() {
         Teildatensatz tds = new Teildatensatz(100, 1);
         Zeichen satznummer = new Zeichen(new Bezeichner("Satznummer"), 256);
@@ -132,7 +134,30 @@ public class TeildatensatzTest extends AbstractSatzTest {
         tds.add(satznummer);
         assertEquals(satznummer, tds.getFeld(satznummer.getBezeichnung()));
         tds.remove(satznummer.getBezeichnung());
-        assertEquals("remove failed", Feld.NULL_FELD, tds.getFeld(satznummer.getBezeichnung()));
+        try {
+            tds.getFeld(satznummer.getBezeichnung());
+            fail("IllegalArgumentException bei fehlendem Feld erwartet");
+        } catch (IllegalArgumentException ex) {
+            assertThat("Exception sollte Bezeichner und Satzart beschreiben", ex.getMessage(), 
+                    allOf(containsString("Satznummer"), containsString("Satzart 0100")));
+            throw ex;
+        }
+    }
+    
+    /**
+     * Bei der internen Umstellung des {@link Teildatensatz}es auf die
+     * erweiterte {@link Bezeichner}-Klasse gab es Probleme mit dem Loeschen
+     * von Feldern.
+     */
+    @Test
+    public void testRemoveSafe() {
+        Teildatensatz tds = new Teildatensatz(100, 1);
+        Zeichen satznummer = new Zeichen(new Bezeichner("Satznummer"), 256);
+        satznummer.setInhalt('1');
+        tds.add(satznummer);
+        assertEquals(satznummer, tds.getFeld(satznummer.getBezeichnung()));
+        tds.remove(satznummer.getBezeichnung());
+        assertEquals("remove failed", Feld.NULL_FELD, tds.getFeldSafe(satznummer.getBezeichnung()));
     }
 
     /**

--- a/lib/src/test/java/gdv/xport/satz/xml/TeildatensatzXmlTest.java
+++ b/lib/src/test/java/gdv/xport/satz/xml/TeildatensatzXmlTest.java
@@ -18,7 +18,11 @@
 
 package gdv.xport.satz.xml;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -123,12 +127,35 @@ public class TeildatensatzXmlTest extends TeildatensatzTest {
      */
     @Test
     public void testGetLeerstellen() {
-        checkLeerstellen(1, Feld.NULL_FELD);
+        try {
+            satz100.getTeildatensatz(1).getFeld(new Bezeichner("Leerstellen"));
+            fail("IllegalArgumentException bei fehlendem Feld erwartet");
+        } catch (IllegalArgumentException ex) {
+            assertThat("Exception sollte Bezeichner und Satzart beschreiben", ex.getMessage(), 
+                    allOf(containsString("Leerstellen"), containsString("Satzart 0100")));
+        }
+        
         checkLeerstellen(2, new AlphaNumFeld(Feld100.LEERSTELLEN));
     }
 
     private void checkLeerstellen(final int satznummer, final Feld expected) {
         Feld leerstellen = satz100.getTeildatensatz(satznummer).getFeld(new Bezeichner("Leerstellen"));
+        assertEquals(expected.getAnzahlBytes(), leerstellen.getAnzahlBytes());
+        assertEquals(expected.getByteAdresse(), leerstellen.getByteAdresse());
+    }
+    
+    /**
+     * Im ersten Teildatensatz von Satz 100 gibt es keine Leerstellen.
+     * Deshalb sollte hier ein Null-Feld zurueckgegeben werden.
+     */
+    @Test
+    public void testGetLeerstellenSafe() {
+        checkLeerstellenSafe(1, Feld.NULL_FELD);
+        checkLeerstellenSafe(2, new AlphaNumFeld(Feld100.LEERSTELLEN));
+    }
+
+    private void checkLeerstellenSafe(final int satznummer, final Feld expected) {
+        Feld leerstellen = satz100.getTeildatensatz(satznummer).getFeldSafe(new Bezeichner("Leerstellen"));
         assertEquals(expected.getAnzahlBytes(), leerstellen.getAnzahlBytes());
         assertEquals(expected.getByteAdresse(), leerstellen.getByteAdresse());
     }


### PR DESCRIPTION
Satz.getFeldSafe hinzugefügt (Feld.NULL_FELD statt IllegalArgumentException) und in Teildatensatz überschrieben.
Teildatensatz.getFeld wirft nun auch eine IllegalArgumentException.
Satz nutzt getFeldSafe, wo nötig.
Tests für das neue Verhalten von Teildatensatz angepasst und erweitert.