### PR TITLE
Update build.adoc

### DIFF
--- a/doc/build.adoc
+++ b/doc/build.adoc
@@ -61,7 +61,7 @@ docker build -t gdv.xport -f Dockerfile .
 Danach kann dieser Docker-Container über
 
 ```
-docker run -p 2517:2517 gdv.xport
+docker run --rm -p 2517:2517 gdv.xport
 ```
 
 gestartet und unter http://localhost:2517/ aufgerufen werden.


### PR DESCRIPTION
`rm` bei run löscht den Container, wenn er beendet wird. Der Container wird nach dem Ausführen nicht mehr gebraucht und ein Erzeugen eines neuen Containers vom Image ist billig.