### PR TITLE
Parsen von Teildatensätzen noch fehlerhaft

### DIFF
--- a/lib/src/test/java/gdv/xport/satz/feld/sparte140/Feld220Test.java
+++ b/lib/src/test/java/gdv/xport/satz/feld/sparte140/Feld220Test.java
@@ -40,11 +40,11 @@ public class Feld220Test extends AbstractDatensatzTest {
     @Test
     public void testTeildatensaetze() throws IOException {
         String input = 
-                  "02209999  140      59999999997019999009999                      "
+                  "02209999  140      59999999997019999009999        1             "
                 + "                                                                "
                 + "                                                                "
-                + "                                                               1" + "\n"
-                + "02209999  140      59999999997019999009999                      "
+                + "                                                                " + "\n"
+                + "02209999  140      59999999997019999009999        2             "
                 + "                                                                "
                 + "                                                                "
                 + "                                                               2" + "\n";


### PR DESCRIPTION
1. Aufgefallen bei zwei nacheinanderfolgenden Datensätzen mit Satzart 0500 (beides mal Teildatensatz 1). Sofern ein Datensatz noch als alte Version daherkommt (1.5, wo noch keine Satznummer gesetzt wurde), so wurde der zweite Datensatz fälschlicherweise als Teildatensatz 2 vom ersten Datensatz geparst => zwei neue Unit-Tests
2. Aufgefallen bei Musterdatei (musterdatei_041222.txt, z.B. Zeilen 7 - 10). Reihenfolge wie folgt:
0220.030/1
0220.030/2
0221.030/2
0220.030/3 -> Wurde als Teildatensatz 1 eines neuen 0220.030 Datensatzes erkannt, müsste aber als Teildatensatz 3 geparst werden. -> Erweiterung UnitTest DatenpaketTest.testImportFromFile