### PR TITLE
Fix für Feld JahresrenteInWaehrungseinheiten in SatzTyp 0220.010.9.1 in xmls 

### DIFF
--- a/lib/src/main/resources/gdv/xport/satz/xml/VUVM2009.xml
+++ b/lib/src/main/resources/gdv/xport/satz/xml/VUVM2009.xml
@@ -16166,9 +16166,9 @@
                 <bemerkung>TTMMJJJJ</bemerkung>
             </feldreferenz>
             <!-- NumFeld JahresrenteInWE (235-248) -->
-            <feldreferenz referenz="235-248-JahresrenteInWE-Fliesskomma">
+            <feldreferenz referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
                 <name>Jahresrente in Währungseinheiten</name>
-                <technischerName>JahresrenteInWE</technischerName>
+                <technischerName>JahresrenteInWaehrungseinheiten</technischerName>
             </feldreferenz>
             <!-- AlphaNumFeld Leerstellen (249-255) -->
             <feldreferenz referenz="249-255-Leerstellen-Alphanumerisch">
@@ -46155,7 +46155,7 @@
             <bytes>10</bytes>
             <datentyp>Alphanumerisch</datentyp>
         </feld>
-        <feld referenz="235-248-JahresrenteInWE-Fliesskomma">
+        <feld referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
             <name>Jahresrente in Währungseinheiten</name>
             <bytes>14</bytes>
             <datentyp>Fliesskomma</datentyp>

--- a/lib/src/main/resources/gdv/xport/satz/xml/VUVM2013.xml
+++ b/lib/src/main/resources/gdv/xport/satz/xml/VUVM2013.xml
@@ -16361,9 +16361,9 @@
                 <bemerkung>TTMMJJJJ</bemerkung>
             </feldreferenz>
             <!-- NumFeld JahresrenteInWE (235-248) -->
-            <feldreferenz referenz="235-248-JahresrenteInWE-Fliesskomma">
+            <feldreferenz referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
                 <name>Jahresrente in Währungseinheiten</name>
-                <technischerName>JahresrenteInWE</technischerName>
+                <technischerName>JahresrenteInWaehrungseinheiten</technischerName>
             </feldreferenz>
             <!-- AlphaNumFeld Leerstellen (249-255) -->
             <feldreferenz referenz="249-255-Leerstellen-Alphanumerisch">
@@ -46846,7 +46846,7 @@
             <bytes>10</bytes>
             <datentyp>Alphanumerisch</datentyp>
         </feld>
-        <feld referenz="235-248-JahresrenteInWE-Fliesskomma">
+        <feld referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
             <name>Jahresrente in Währungseinheiten</name>
             <bytes>14</bytes>
             <datentyp>Fliesskomma</datentyp>

--- a/lib/src/main/resources/gdv/xport/satz/xml/VUVM2015.xml
+++ b/lib/src/main/resources/gdv/xport/satz/xml/VUVM2015.xml
@@ -16547,9 +16547,9 @@
                 <bemerkung>TTMMJJJJ</bemerkung>
             </feldreferenz>
             <!-- NumFeld JahresrenteInWE (235-248) -->
-            <feldreferenz referenz="235-248-JahresrenteInWE-Fliesskomma">
+            <feldreferenz referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
                 <name>Jahresrente in Währungseinheiten</name>
-                <technischerName>JahresrenteInWE</technischerName>
+                <technischerName>JahresrenteInWaehrungseinheiten</technischerName>
             </feldreferenz>
             <!-- AlphaNumFeld Leerstellen (249-255) -->
             <feldreferenz referenz="249-255-Leerstellen-Alphanumerisch">
@@ -47200,7 +47200,7 @@
             <bytes>10</bytes>
             <datentyp>Alphanumerisch</datentyp>
         </feld>
-        <feld referenz="235-248-JahresrenteInWE-Fliesskomma">
+        <feld referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
             <name>Jahresrente in Währungseinheiten</name>
             <bytes>14</bytes>
             <datentyp>Fliesskomma</datentyp>

--- a/lib/src/main/resources/gdv/xport/satz/xml/VUVM2018.xml
+++ b/lib/src/main/resources/gdv/xport/satz/xml/VUVM2018.xml
@@ -16702,9 +16702,9 @@
                 <bemerkung>TTMMJJJJ</bemerkung>
             </feldreferenz>
             <!-- NumFeld JahresrenteInWE (235-248) -->
-            <feldreferenz referenz="235-248-JahresrenteInWE-Fliesskomma">
+            <feldreferenz referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
                 <name>Jahresrente in Währungseinheiten</name>
-                <technischerName>JahresrenteInWE</technischerName>
+                <technischerName>JahresrenteInWaehrungseinheiten</technischerName>
             </feldreferenz>
             <!-- AlphaNumFeld Leerstellen (249-255) -->
             <feldreferenz referenz="249-255-Leerstellen-Alphanumerisch">
@@ -47602,7 +47602,7 @@
             <bytes>10</bytes>
             <datentyp>Alphanumerisch</datentyp>
         </feld>
-        <feld referenz="235-248-JahresrenteInWE-Fliesskomma">
+        <feld referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
             <name>Jahresrente in Währungseinheiten</name>
             <bytes>14</bytes>
             <datentyp>Fliesskomma</datentyp>

--- a/lib/src/main/resources/gdv/xport/satz/xml/VUVM2023.xml
+++ b/lib/src/main/resources/gdv/xport/satz/xml/VUVM2023.xml
@@ -16894,9 +16894,9 @@
 				<bemerkung>TTMMJJJJ</bemerkung>
 			</feldreferenz>
 			<!-- NumFeld JahresrenteInWE (235-248) -->
-			<feldreferenz referenz="235-248-JahresrenteInWE-Fliesskomma">
+			<feldreferenz referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
 				<name>Jahresrente in Währungseinheiten</name>
-				<technischerName>JahresrenteInWE</technischerName>
+                <technischerName>JahresrenteInWaehrungseinheiten</technischerName>
 			</feldreferenz>
 			<!-- AlphaNumFeld Leerstellen (249-255) -->
 			<feldreferenz referenz="249-255-Leerstellen-Alphanumerisch">
@@ -47945,7 +47945,7 @@
 			<bytes>10</bytes>
 			<datentyp>Alphanumerisch</datentyp>
 		</feld>
-		<feld referenz="235-248-JahresrenteInWE-Fliesskomma">
+		<feld referenz="235-248-JahresrenteInWaehrungseinheiten-Fliesskomma">
 			<name>Jahresrente in Währungseinheiten</name>
 			<bytes>14</bytes>
 			<datentyp>Fliesskomma</datentyp>


### PR DESCRIPTION
Beim Feld JahresrenteInWaehrungseinheiten (Feld Nr. 31 in Teildatensatz 2) wurde der technische Name nicht korrekt aus den XMLs vom GDV übernommen. Das führte dazu, dass es innerhalb des SatzTyps zwei Felder mit technischem Namen "JahresrenteInWE" gab, sodass der Zugriff über den technischen Namen allein nicht mehr eindeutig möglich war.

Ich habe hier bisher nur die xmls korrigiert, es dürfte im GdvXmlFormatter einen Bug geben, der zu dem Problem geführt hat.