### PR TITLE
Methode getBetragMitVorzeichen in Satz erweitert, damit auch leere Vorzeichen für Betrag 0 erlaubt sind.

### DIFF
--- a/lib/src/test/java/gdv/xport/satz/SatzTest.java
+++ b/lib/src/test/java/gdv/xport/satz/SatzTest.java
@@ -215,6 +215,24 @@ public final class SatzTest extends AbstractSatzTest {
         assertEquals(new BigDecimal("-1.23"), betrag.toBigDecimal());
     }
 
+    @Test
+    public void testGetBetragMitLeeremVorzeichen() {
+        Satz satz = SatzFactory.getSatz(SatzTyp.of(500));
+        satz.setFeld(Bezeichner.SCHADENBEARBEITUNGSKOSTEN_IN_WAEHRUNGSEINHEITEN, "00000001234");
+        satz.getTeildatensatz(1).setFeld(ByteAdresse.of(167), "");
+
+        // Leeres Vorzeichen, aber nicht leerer Betrag -> IllegalStateException
+        assertThrows(IllegalStateException.class, () -> satz.getFeld(Bezeichner.SCHADENBEARBEITUNGSKOSTEN_IN_WAEHRUNGSEINHEITEN, BetragMitVorzeichen.class));
+
+        // Leeres Vorzeichen und Betrag 0 -> Vorzeichen-Feld weiter leer, aber der Betrag mit Vorzeichen ist "+0"
+        satz.setFeld(Bezeichner.SCHADENBEARBEITUNGSKOSTEN_IN_WAEHRUNGSEINHEITEN, "00000000000");
+        BetragMitVorzeichen betrag = satz.getFeld(Bezeichner.SCHADENBEARBEITUNGSKOSTEN_IN_WAEHRUNGSEINHEITEN, BetragMitVorzeichen.class);
+        assertEquals(14, betrag.getAnzahlBytes());
+        assertEquals('+', betrag.getVorzeichen());
+        assertEquals(" ", satz.getFeld(ByteAdresse.of(167)).getInhalt());
+        assertEquals(0, betrag.toBigDecimal().compareTo(BigDecimal.ZERO));
+    }
+
     /**
      * Testfall fuer Issue #12.
      */


### PR DESCRIPTION
Siehe #96.